### PR TITLE
chore: remove Node.js version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Prepare your environment:
 
 1. Install [![required Node.js version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fwww.unpkg.com%2F%40sap%2Fcds-lsp%2Fpackage.json&query=%24.engines.node&label=Node.js&cacheSeconds=3600)](https://nodejs.org/en/)
    on your computer.
-2. Make sure that your IntelliJ IDEA Ultimate (or other commercial IntelliJ IDE) runs with a `PATH` that includes the Node.js executable.
+2. Make sure that IntelliJ *IDEA Ultimate* or *WebStorm* runs with a `PATH` that includes the Node.js executable.
 3. If you have installed the SAP CDS Language Support for IntelliJ plugin from a Zip file before, uninstall it.
      - Note: we have reset the current plugin version to `1.0.0` for the first JetBrains Marketplace release, to clarify that the feature set (based on the current LSP API) is still incomplete.
 

--- a/src/main/java/com/sap/cap/cds/intellij/lsp/ServerDescriptor.java
+++ b/src/main/java/com/sap/cap/cds/intellij/lsp/ServerDescriptor.java
@@ -27,7 +27,7 @@ public class ServerDescriptor extends ProjectWideLspServerDescriptor {
     private static final String RELATIVE_MITM_PATH = "cds-lsp/mitm.js";
     private static final String RELATIVE_LOG_PATH = "cds-lsp/stdio.json";
 
-    private volatile boolean started;
+    private boolean started;
 
     public ServerDescriptor(@NotNull Project project, @NotNull String presentableName) {
         super(project, presentableName);

--- a/src/main/java/com/sap/cap/cds/intellij/lsp/ServerDescriptor.java
+++ b/src/main/java/com/sap/cap/cds/intellij/lsp/ServerDescriptor.java
@@ -9,23 +9,18 @@ import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor;
 import com.intellij.platform.lsp.api.customization.LspFormattingSupport;
 import com.intellij.util.io.BaseOutputReader;
 import com.sap.cap.cds.intellij.FileType;
-import com.sap.cap.cds.intellij.util.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.apache.maven.artifact.versioning.ComparableVersion;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static com.intellij.util.PathUtil.getJarPathForClass;
-import static com.sap.cap.cds.intellij.util.JsonUtil.getPropertyAtPath;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ServerDescriptor extends ProjectWideLspServerDescriptor {
 
     private static final String RELATIVE_SERVER_PATH = "cds-lsp/node_modules/@sap/cds-lsp/dist/main.js";
-    private static final String RELATIVE_SERVER_PKG_PATH = "cds-lsp/node_modules/@sap/cds-lsp/package.json";
     private static final String RELATIVE_MITM_PATH = "cds-lsp/mitm.js";
     private static final String RELATIVE_LOG_PATH = "cds-lsp/stdio.json";
 
@@ -36,8 +31,6 @@ public class ServerDescriptor extends ProjectWideLspServerDescriptor {
     @NotNull
     @Override
     public OSProcessHandler startServerProcess() throws ExecutionException {
-        checkNodeVersion();
-
         OSProcessHandler handler = new OSProcessHandler(getCommandLine()) {
             @Override
             protected BaseOutputReader.@NotNull Options readerOptions() {
@@ -55,36 +48,6 @@ public class ServerDescriptor extends ProjectWideLspServerDescriptor {
             handleServerError(exitValue);
         } catch (RuntimeException e) { /* process still running */ }
         return handler;
-    }
-
-    private void checkNodeVersion() {
-        String requiredVersionStr = "";
-        try {
-            String serverPkg = new String(Files.readAllBytes(Paths.get(resolve(RELATIVE_SERVER_PKG_PATH))));
-            requiredVersionStr = getPropertyAtPath(serverPkg, new String[]{"engines", "node"}).toString();
-        } catch (Exception e) {
-            UserError.show("Cannot determine Node.js version required by CDS Language Server.", e);
-            return;
-        }
-        requiredVersionStr = requiredVersionStr.replaceAll("[^\\d.]", "");
-
-        String versionStr = "";
-        try {
-            Process process = new ProcessBuilder("node", "--version").start();
-            versionStr = new String(process.getInputStream().readAllBytes()).trim();
-        } catch (Exception e) {
-            UserError.show("Cannot determine Node.js version. Please make sure Node.js is installed and available in the PATH.", e);
-            return;
-        }
-        if (versionStr.startsWith("v")) {
-            versionStr = versionStr.substring(1);
-        }
-
-        ComparableVersion requiredVersion = new ComparableVersion(requiredVersionStr);
-        ComparableVersion version = new ComparableVersion(versionStr);
-        if (version.compareTo(requiredVersion) < 0) {
-            UserError.show("CDS Language Server requires Node.js version %s, but found earlier Node.js version %s. Please update your Node.js installation.".formatted(requiredVersionStr, versionStr));
-        }
     }
 
     private void handleServerError(int exitValue) {

--- a/src/main/java/com/sap/cap/cds/intellij/lsp/ServerDescriptor.java
+++ b/src/main/java/com/sap/cap/cds/intellij/lsp/ServerDescriptor.java
@@ -52,18 +52,16 @@ public class ServerDescriptor extends ProjectWideLspServerDescriptor {
         try {
             Thread.sleep(2000);
         } catch (InterruptedException e) { /*ignore*/ }
-        tryHandleServerError(handler);
+        checkServerRunning(handler);
         return handler;
     }
 
-    private void tryHandleServerError(OSProcessHandler handler) {
+    private void checkServerRunning(OSProcessHandler handler) {
         Process process = handler.getProcess();
-        try {
-            process.exitValue();
-            showUserError(process);
-        } catch (RuntimeException e) {
-            // process is running
+        if (process.isAlive()) {
             started = true;
+        } else {
+            showUserError(process);
         }
     }
 

--- a/src/main/java/com/sap/cap/cds/intellij/lsp/ServerDescriptor.java
+++ b/src/main/java/com/sap/cap/cds/intellij/lsp/ServerDescriptor.java
@@ -27,7 +27,7 @@ public class ServerDescriptor extends ProjectWideLspServerDescriptor {
     private static final String RELATIVE_MITM_PATH = "cds-lsp/mitm.js";
     private static final String RELATIVE_LOG_PATH = "cds-lsp/stdio.json";
 
-    private volatile Boolean started = false;
+    private volatile boolean started;
 
     public ServerDescriptor(@NotNull Project project, @NotNull String presentableName) {
         super(project, presentableName);

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -57,16 +57,6 @@ The set of features will grow with future releases, aligned with the development
 
     <change-notes><![CDATA[ <h3>Changed</h3>
 <ul>
-    <li>include @sap/cds-lsp 8.2.1 with:
-        <ul>
-            <li>code completion for artifacts within `using` statements now also completes single name segments with complete name</li>
-            <li>minimum required Node.js version is now 20.9.0</li>
-            <li>hover and completion proposal details now show artifact kind</li>
-            <li>fix: highlighting of element names in annotate statements and of special element names `entity`, `type`, `event`</li>
-            <li>fix: completion: rename of source folders led to wrong using path proposals</li>
-            <li>fix: completion: using path proposals did not work in multi-line using statements</li>
-            <li>fix: maintain translation quickfix sent wrong document version</li>
-        </ul>
-    </li>
+    <li>remove Node.js version check, which is now done by the LSP server</li>
 </ul> ]]></change-notes>
 </idea-plugin>


### PR DESCRIPTION
fixes https://github.com/cap-js/cds-intellij/issues/47

On startup with a Node version mismatch, this will show the original error from the cds-lsp server:
![grafik](https://github.com/user-attachments/assets/7a20e6b1-d549-47d8-bec8-987797403277)
