### PR TITLE
fix: treat tabSize default value specially

### DIFF
--- a/src/js/codestyle/patchJavaSrc.js
+++ b/src/js/codestyle/patchJavaSrc.js
@@ -135,6 +135,7 @@ const options = Object.entries(optsFromSchema)
 
 const t = '    ';
 
+// START CLASS BODY
 const classBody = `
 ${t}public static final String SAMPLE_SRC = """
 ${n = `${t}public static final String SAMPLE_SRC = `.length, sample.replace(/^/gm, ' '.repeat(n))}
@@ -155,6 +156,9 @@ ${Object.entries(categoryGroups).map(([category, groups]) =>
 ${t}}
 ${t}public CdsCodeStyleSettings(CodeStyleSettings settings) {
 ${t}${t}super(settings);
+${t}${t}settings.initIndentOptions();
+${t}${t}settings.getIndentOptions().INDENT_SIZE = this.tabSize;
+${t}${t}settings.getIndentOptions().USE_TAB_CHARACTER = false;
 ${t}}
 
 ${options.map(opt => `${t}public ${opt.fieldType} ${opt.name} = ${opt.default};`).join('\n')}
@@ -167,6 +171,7 @@ ${t}${t}int getId();
 ${t}}
 
 `;
+// END CLASS BODY
 
 const patchedSrc = src.replace(
     /(?<=public class CdsCodeStyleSettings [\w ]*\{\n).*(?=^})/sm,

--- a/src/main/java/com/sap/cap/cds/intellij/codestyle/CdsCodeStyleCheckboxesPanel.java
+++ b/src/main/java/com/sap/cap/cds/intellij/codestyle/CdsCodeStyleCheckboxesPanel.java
@@ -78,6 +78,7 @@ public class CdsCodeStyleCheckboxesPanel extends OptionTreeWithPreviewPanel impl
         super.apply(settings); // Applies settings from UI to the settings object
         CdsCodeStyleSettings cdsSettings = settings.getCustomSettings(CdsCodeStyleSettings.class);
         setOptionsEnablement(cdsSettings.getChildOptionsEnablement(category));
+        settings.getIndentOptions().INDENT_SIZE = cdsSettings.tabSize;
         CdsCodeStylePreviewFormattingService.acceptSettings(cdsSettings);
     }
 

--- a/src/main/java/com/sap/cap/cds/intellij/codestyle/CdsCodeStyleSettings.java
+++ b/src/main/java/com/sap/cap/cds/intellij/codestyle/CdsCodeStyleSettings.java
@@ -145,6 +145,9 @@ public class CdsCodeStyleSettings extends CdsCodeStyleSettingsBase {
     }
     public CdsCodeStyleSettings(CodeStyleSettings settings) {
         super(settings);
+        settings.initIndentOptions();
+        settings.getIndentOptions().INDENT_SIZE = this.tabSize;
+        settings.getIndentOptions().USE_TAB_CHARACTER = false;
     }
 
     public boolean alignActionNames = true;


### PR DESCRIPTION
Since this param is sent with any textDocument/formatting request, LSP API inserts a default value (which differs from ours) unless configured in indentOptions.