### PR TITLE
ci: remove caching due to big storage overhead

### DIFF
--- a/.github/actions/gradle-run/action.yml
+++ b/.github/actions/gradle-run/action.yml
@@ -34,8 +34,9 @@ runs:
       with:
         path: |
           /root/.gradle/caches/modules-2
-          !~/.gradle/caches/modules-2/files-*
+          /root/.gradle/caches/build-cache-1
           /root/.gradle/wrapper
+          !~/.gradle/caches/modules-2/files-*
         key: ${{ runner.os }}-gradle-${{ hashFiles('build.gradle', 'gradle.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-

--- a/.github/actions/gradle-run/action.yml
+++ b/.github/actions/gradle-run/action.yml
@@ -35,7 +35,6 @@ runs:
       with:
         path: |
           /root/.gradle/caches/modules-2
-          !~/.gradle/caches/modules-2/files-*
           /root/.gradle/caches/build-cache-1
           /root/.gradle/wrapper
         key: ${{ runner.os }}-gradle-${{ hashFiles('build.gradle', 'gradle.properties') }}
@@ -72,3 +71,14 @@ runs:
       shell: bash
       run: |
         ./gradlew publishPlugin --info --no-daemon
+
+    - name: Keep only small files for caching, which are faster to compress than to download
+      run: |
+        # Good thresholds as per measurement: currently 500 kB, more future-proof 900 kB.
+        # Reason for latter: request duration dominated by ~constant request overhead, but compression time to decrease. 
+        # Measurements: cache size (uncompr.) 1800 MB, compr. time 230 s, restoration time 6 s
+        # Assumptions: req. overhead 60 ms, current download rate 110 MB/s
+        find /root/.gradle/caches/modules-2     -type f -size +900k -delete
+        find /root/.gradle/caches/build-cache-1 -type f -size +900k -delete
+        find /root/.gradle/wrapper              -type f -size +900k -delete
+      shell: bash

--- a/.github/actions/gradle-run/action.yml
+++ b/.github/actions/gradle-run/action.yml
@@ -29,18 +29,23 @@ runs:
         distribution: zulu
         java-version: 21
 
+
     - name: Cache Gradle dependencies
       uses: actions/cache@v3
       with:
         path: |
           /root/.gradle/caches/modules-2
+          !~/.gradle/caches/modules-2/files-*
           /root/.gradle/caches/build-cache-1
           /root/.gradle/wrapper
-          !~/.gradle/caches/modules-2/files-*
         key: ${{ runner.os }}-gradle-${{ hashFiles('build.gradle', 'gradle.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
 
+    - name: Debug cache size
+      run: |
+        [[ -d /root/.gradle ]] && find /root/.gradle -type f -exec du -h {} + | sort -rh | head -n 100 || true
+      shell: bash
 
     - name: Test
       if: ${{ contains(inputs.steps, 'test') }}

--- a/.github/actions/gradle-run/action.yml
+++ b/.github/actions/gradle-run/action.yml
@@ -34,9 +34,8 @@ runs:
       with:
         path: |
           /root/.gradle/caches/modules-2
-          /root/.gradle/caches/build-cache-1
-          /root/.gradle/wrapper
           !~/.gradle/caches/modules-2/files-*
+          /root/.gradle/wrapper
         key: ${{ runner.os }}-gradle-${{ hashFiles('build.gradle', 'gradle.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-

--- a/.github/actions/gradle-run/action.yml
+++ b/.github/actions/gradle-run/action.yml
@@ -29,23 +29,6 @@ runs:
         distribution: zulu
         java-version: 21
 
-
-    - name: Cache Gradle dependencies
-      uses: actions/cache@v3
-      with:
-        path: |
-          /root/.gradle/caches/modules-2
-          /root/.gradle/caches/build-cache-1
-          /root/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('build.gradle', 'gradle.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-
-    - name: Debug cache size
-      run: |
-        [[ -d /root/.gradle ]] && find /root/.gradle -type f -exec du -h {} + | sort -rh | head -n 100 || true
-      shell: bash
-
     - name: Test
       if: ${{ contains(inputs.steps, 'test') }}
       shell: bash
@@ -71,14 +54,3 @@ runs:
       shell: bash
       run: |
         ./gradlew publishPlugin --info --no-daemon
-
-    - name: Keep only small files for caching, which are faster to compress than to download
-      run: |
-        # Good thresholds as per measurement: currently 500 kB, more future-proof 900 kB.
-        # Reason for latter: request duration dominated by ~constant request overhead, but compression time to decrease. 
-        # Measurements: cache size (uncompr.) 1800 MB, compr. time 230 s, restoration time 6 s
-        # Assumptions: req. overhead 60 ms, current download rate 110 MB/s
-        find /root/.gradle/caches/modules-2     -type f -size +900k -delete
-        find /root/.gradle/caches/build-cache-1 -type f -size +900k -delete
-        find /root/.gradle/wrapper              -type f -size +900k -delete
-      shell: bash


### PR DESCRIPTION
It took 138 s to save even a small cache of 56 MB size.