### PR TITLE
build(deps): upgrade cds-lsp to 9.9.0 and gradle to 9.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ platformVersion = 2025.1
 # platformPlugins =
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 9.4.0
+gradleVersion = 9.5.0
 
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html
 org.gradle.configuration-cache = true

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@sap/cds-lsp": "9.8.0"
+    "@sap/cds-lsp": "9.9.0"
   }
 }

--- a/src/main/java/com/sap/cap/cds/intellij/usersettings/CdsUserSettings.java
+++ b/src/main/java/com/sap/cap/cds/intellij/usersettings/CdsUserSettings.java
@@ -184,7 +184,7 @@ public class CdsUserSettings {
         defaults.put("cds.workspaceSymbols.caseInsensitive", false);
         defaults.put("cds.typeGenerator.enabled", false);
         defaults.put("cds.typeGenerator.outputPath", "./@cds-models");
-        defaults.put("cds.typeGenerator.command", "${typerBinary} \"${targetFile}\" --outputDirectory \"${outputDirectory}\"");
+        defaults.put("cds.typeGenerator.command", "\"${typerBinary}\" \"${targetFile}\" --outputDirectory \"${outputDirectory}\"");
         defaults.put("sapbas.telemetryEnabled", true);
         defaults.put("cds.diagnosticsSeverity", "Warning");
         defaults.put("cds.compiler.markMissingI18nDefault", false);


### PR DESCRIPTION
# Upgrade cds-lsp to 9.9.0 and Gradle to 9.5.0

### Chore

🔧 Bumped dependency versions and applied a minor fix to the type generator command default setting.

### Changes

* `gradle.properties`: Updated Gradle version from `9.4.0` to `9.5.0`.
* `lsp/package.json`: Upgraded `@sap/cds-lsp` dependency from `9.8.0` to `9.9.0`.
* `src/main/java/com/sap/cap/cds/intellij/usersettings/CdsUserSettings.java`: Fixed the default value for `cds.typeGenerator.command` to properly quote `${typerBinary}`, ensuring paths with spaces are handled correctly.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.37`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `688c2a71-33c6-469b-aeca-065b5e3dd912`
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
