### PR TITLE
chore(release): bump version to 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
                 'org.jetbrains.plugins.textmate'
         ])
 
-        plugin("com.redhat.devtools.lsp4ij:0.19.2")
+        plugin("com.redhat.devtools.lsp4ij:0.20.1")
 
         pluginVerifier()
         testFramework(TestFrameworkType.Platform.INSTANCE)

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 archiveName = cds-intellij.zip
 pluginRepositoryUrl = https://github.com/cap-js/cds-intellij
 # SemVer format -> https://semver.org
-pluginVersion = 2.4.0
+pluginVersion = 3.0.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@sap/cds-lsp": "9.9.0"
+    "@sap/cds-lsp": "10.0.1"
   }
 }

--- a/src/main/java/com/sap/cap/cds/intellij/usersettings/CdsUserSettings.java
+++ b/src/main/java/com/sap/cap/cds/intellij/usersettings/CdsUserSettings.java
@@ -41,7 +41,7 @@ public class CdsUserSettings {
             case "cds.completion.workspaceSymbols.useShortname" -> "When using workspace symbols proposals, only match the short name (last name segment) instead of the fully qualified name";
             case "cds.whereused.showGenericAnnotations" -> "Find usages of same annotation names via <i>References</i> command and explicit annotation definitions via <i>Definition</i> command";
             case "cds.whereused.showStringConstants" -> "Find same string constants via <i>References</i> command";
-            case "cds.workspace.persistency.enabled" -> "(Beta) Enable persistency of where-used indexes for faster access of references and workspace symbols";
+            case "cds.workspace.persistency.enabled" -> "Enable persistency of where-used indexes for faster access of references and workspace symbols";
             case "cds.workspace.persistency.persistAfterSave" -> "Persist where-used index of a CDS model file after save";
             case "cds.workspace.persistency.persistAfterCompile" -> "Persist where-used indexes after a compile e.g. when changing a file";
             case "cds.workspace.persistency.restoreBeforeCompile" -> "When compiling a model reuse persisted where-used indexes of dependent models";
@@ -169,7 +169,7 @@ public class CdsUserSettings {
         defaults.put("cds.completion.workspaceSymbols.useShortname", false);
         defaults.put("cds.whereused.showGenericAnnotations", false);
         defaults.put("cds.whereused.showStringConstants", false);
-        defaults.put("cds.workspace.persistency.enabled", false);
+        defaults.put("cds.workspace.persistency.enabled", true);
         defaults.put("cds.workspace.persistency.persistAfterSave", true);
         defaults.put("cds.workspace.persistency.persistAfterCompile", true);
         defaults.put("cds.workspace.persistency.restoreBeforeCompile", true);

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -182,16 +182,23 @@
     <change-notes><![CDATA[
 <h4>Changed</h4>
 <ul>
-    <li>Upgrade @sap/cds-lsp from 9.8.0 to 9.9.0 with the following additions and changes:
+    <li>Upgrade @sap/cds-lsp from 9.8.0 to 10.0.1 with the following additions and changes:
         <ul>
+            <li>Formatting: new option <code>annotationInNewLine</code> to start elements on a new line after their annotation in <code>annotate</code> blocks</li>
+            <li>Formatting: new option <code>asProjectionInNewLine</code> to start <code>as projection on</code> / <code>as select from</code> in a new line (indented)</li>
+            <li>Formatting: new option <code>conditionInNewLine</code> to put ON conditions on a separate line</li>
             <li>WorkspaceSymbols: also include models defined in build tasks</li>
+            <li>index persistency is enabled by default, can be switched off via user setting <code>cds.workspace.persistency.enabled</code></li>
+            <li>Fixed: Formatting: align post-annotations (e.g. <code>@mandatory</code>) in parameter lists</li>
+            <li>Fixed: Formatting: align <code>virtual</code> and <code>element</code> keyword modifiers with element name if <code>alignAfterKey</code> is set</li>
             <li>Fixed: Support lookup dirs defined in subfolders e.g. pom.xml (resolve cds env per project root instead of workspace root)</li>
             <li>Fixed: WorkspaceSymbols: NodeJS V8 crashed for very large workspaces</li>
             <li>Fixed: WorkspaceSymbols: filter out symbols from ignored files</li>
             <li>Fixed: Add quotes around the binary in the default cds-typer command to support paths with non-alphanumeric characters</li>
         </ul>
     </li>
+    <li>Upgrade LSP4IJ to 0.20.1, fixing memory leaks, editor-thread (EDT) errors, and code-action consistency</li>
 </ul>
-<p><em>For details see the <a href=https://github.com/cap-js/cds-intellij/compare/2.3.1...2.4.0>full changelog</a></em></p>
+<p><em>For details see the <a href=https://github.com/cap-js/cds-intellij/compare/2.3.1...3.0.0>full changelog</a></em></p>
 ]]></change-notes>
 </idea-plugin>

--- a/src/test/data/serverIntegration/diagnostics.expected.cds
+++ b/src/test/data/serverIntegration/diagnostics.expected.cds
@@ -2,7 +2,7 @@ type T : Integer;
 
 entity F {
     m : T;
-    n : <error descr="No artifact has been found with name “NotFound”">NotFound</error>;
+    n : <error descr="Artifact “NotFound” has not been found">NotFound</error>;
 }
 
 <error>ntity</error> B {}

--- a/src/test/java/com/sap/cap/cds/intellij/TestUtil.java
+++ b/src/test/java/com/sap/cap/cds/intellij/TestUtil.java
@@ -1,5 +1,7 @@
 package com.sap.cap.cds.intellij;
 
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.testFramework.ExpectedHighlightingData;
@@ -12,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import static java.nio.file.Files.readString;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -40,24 +43,45 @@ public class TestUtil {
     }
     
     private static void waitForLspDiagnostics(@NotNull CodeInsightTestFixture fixture) {
-        boolean serverReady = false;
-        long deadline = System.currentTimeMillis() + SECONDS.toMillis(10);
         var project = fixture.getProject();
-        
-        while (System.currentTimeMillis() < deadline && !serverReady) {
+        long deadline = System.currentTimeMillis() + SECONDS.toMillis(60);
+
+        while (System.currentTimeMillis() < deadline) {
             try {
-                var serverFuture = LanguageServerManager.getInstance(project)
-                    .getLanguageServer(CdsLanguageServer.ID);
-                if (serverFuture.get(100, MILLISECONDS) != null) {
-                    serverReady = true;
-                    // Allow for diagnostics to be sent and processed
-                    Thread.sleep(500);
-                    return;
+                var server = LanguageServerManager.getInstance(project)
+                    .getLanguageServer(CdsLanguageServer.ID)
+                    .get(100, MILLISECONDS);
+                if (server != null) {
+                    break;
                 }
-                Thread.sleep(100);
             } catch (Exception e) {
-                // Ignore and retry
+                // retry until deadline
             }
+            sleep(100);
+        }
+
+        // The server object exists before it has finished indexing and
+        // published diagnostics; startup cost varies with machine speed, so
+        // poll for the diagnostics to arrive rather than waiting a fixed delay.
+        while (System.currentTimeMillis() < deadline) {
+            if (hasErrorDiagnostics(fixture)) {
+                return;
+            }
+            sleep(250);
+        }
+    }
+
+    private static boolean hasErrorDiagnostics(@NotNull CodeInsightTestFixture fixture) {
+        List<HighlightInfo> highlights = fixture.doHighlighting();
+        return highlights.stream()
+            .anyMatch(info -> info.getSeverity() == HighlightSeverity.ERROR);
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 }


### PR DESCRIPTION
# Release: Bump Version to 3.0.0

### Chore

🔖 Version bump to **3.0.0**, upgrading key dependencies including `@sap/cds-lsp` to `10.0.1` and `LSP4IJ` to `0.20.1`, along with enabling workspace index persistency by default.

### Changes

* `gradle.properties`: Bumped plugin version from `2.4.0` to `3.0.0`.
* `build.gradle`: Upgraded `LSP4IJ` dependency from `0.19.2` to `0.20.1`, fixing memory leaks, EDT errors, and code-action consistency.
* `lsp/package.json`: Upgraded `@sap/cds-lsp` from `9.9.0` to `10.0.1`.
* `src/main/java/.../CdsUserSettings.java`:
  - Enabled workspace index persistency by default (`cds.workspace.persistency.enabled` now defaults to `true`).
  - Removed `(Beta)` label from the persistency setting description.
* `src/main/resources/META-INF/plugin.xml`: Updated change notes to reflect the new `@sap/cds-lsp 10.0.1` features and fixes:
  - New formatting options: `annotationInNewLine`, `asProjectionInNewLine`, `conditionInNewLine`.
  - WorkspaceSymbols now includes models from build tasks.
  - Various formatting and WorkspaceSymbols bug fixes.
  - Updated changelog link to reference `2.3.1...3.0.0`.
* `src/test/data/serverIntegration/diagnostics.expected.cds`: Updated expected diagnostic error message wording to match new LSP output (`"Artifact "NotFound" has not been found"`).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.18`

- Event Trigger: `pull_request.opened`
- Correlation ID: `50285e30-9593-11f1-9770-9885683452ba`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
</details>
