### PR TITLE
chore: 3.0.1

### DIFF
--- a/.github/actions/gradle-run/action.yml
+++ b/.github/actions/gradle-run/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: 24
 
     - uses: actions/setup-java@v4
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
                 'org.jetbrains.plugins.textmate'
         ])
 
-        plugin("com.redhat.devtools.lsp4ij:0.21.0")
+        plugin("com.redhat.devtools.lsp4ij:0.20.1")
 
         pluginVerifier()
         testFramework(TestFrameworkType.Platform.INSTANCE)

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
                 'org.jetbrains.plugins.textmate'
         ])
 
-        plugin("com.redhat.devtools.lsp4ij:0.20.1")
+        plugin("com.redhat.devtools.lsp4ij:0.21.0")
 
         pluginVerifier()
         testFramework(TestFrameworkType.Platform.INSTANCE)

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 archiveName = cds-intellij.zip
 pluginRepositoryUrl = https://github.com/cap-js/cds-intellij
 # SemVer format -> https://semver.org
-pluginVersion = 3.0.0
+pluginVersion = 3.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251

--- a/src/main/java/com/sap/cap/cds/intellij/util/CliUtil.java
+++ b/src/main/java/com/sap/cap/cds/intellij/util/CliUtil.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public class CliUtil {
     public static Optional<String> executeCli(String... args) {
         try {
-            Process process = new GeneralCommandLine(args).createProcess();
+            Process process = new GeneralCommandLine(args).withRedirectErrorStream(true).createProcess();
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
                 return Optional.ofNullable(reader.readLine());
             }

--- a/src/test/java/com/sap/cap/cds/intellij/TestUtil.java
+++ b/src/test/java/com/sap/cap/cds/intellij/TestUtil.java
@@ -4,11 +4,12 @@ import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.EditorFactory;
+import com.intellij.openapi.progress.EmptyProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.testFramework.ExpectedHighlightingData;
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
 import com.redhat.devtools.lsp4ij.LanguageServerManager;
-import com.redhat.devtools.lsp4ij.ServerStatus;
 import com.sap.cap.cds.intellij.lsp4ij.CdsLanguageServer;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,6 +17,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static java.nio.file.Files.readString;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -46,32 +50,52 @@ public class TestUtil {
         var project = fixture.getProject();
         long deadline = System.currentTimeMillis() + SECONDS.toMillis(60);
 
-        // Wait for the server to reach 'started' status before calling doHighlighting().
-        // With lsp4ij >= 0.21.0 the feature support uses awaitWithCheckCanceled (no safety
-        // timeout), so triggering highlighting before the server is ready causes an indefinite
-        // hang in the test JVM.
-        while (System.currentTimeMillis() < deadline) {
-            ServerStatus status = LanguageServerManager.getInstance(project)
-                    .getServerStatus(CdsLanguageServer.ID);
-            if (status == ServerStatus.started) {
-                break;
-            }
-            sleep(100);
+        // Block until the server is fully started. getLanguageServer() triggers startup and
+        // resolves when the server is ready. With lsp4ij >= 0.21.0, feature support uses
+        // awaitWithCheckCanceled (no safety timeout), so doHighlighting() must not be called
+        // until the server is ready to respond to LSP requests.
+        try {
+            LanguageServerManager.getInstance(project)
+                    .getLanguageServer(CdsLanguageServer.ID)
+                    .get(60, SECONDS);
+        } catch (Exception e) {
+            // Server did not start in time; proceed — test will likely fail with no highlights.
         }
 
         // Poll for diagnostics to arrive (server may still be indexing after started).
-        while (System.currentTimeMillis() < deadline) {
-            if (hasErrorDiagnostics(fixture)) {
-                return;
+        // Wrap doHighlighting() with a cancellable ProgressIndicator so that lsp4ij's
+        // awaitWithCheckCanceled can bail out if an LSP response hasn't arrived yet,
+        // allowing us to retry rather than blocking indefinitely.
+        ScheduledExecutorService cancelScheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            while (System.currentTimeMillis() < deadline) {
+                if (hasErrorDiagnosticsWithTimeout(fixture, cancelScheduler, 2000)) {
+                    return;
+                }
+                sleep(250);
             }
-            sleep(250);
+        } finally {
+            cancelScheduler.shutdownNow();
         }
     }
 
-    private static boolean hasErrorDiagnostics(@NotNull CodeInsightTestFixture fixture) {
-        List<HighlightInfo> highlights = fixture.doHighlighting();
-        return highlights.stream()
-            .anyMatch(info -> info.getSeverity() == HighlightSeverity.ERROR);
+    private static boolean hasErrorDiagnosticsWithTimeout(@NotNull CodeInsightTestFixture fixture,
+                                                           @NotNull ScheduledExecutorService cancelScheduler,
+                                                           long timeoutMs) {
+        EmptyProgressIndicator indicator = new EmptyProgressIndicator();
+        // Schedule cancellation after timeout so awaitWithCheckCanceled doesn't block forever
+        // if the LSP server hasn't responded yet.
+        var cancelTask = cancelScheduler.schedule(indicator::cancel, timeoutMs, TimeUnit.MILLISECONDS);
+        try {
+            List<HighlightInfo> highlights = ProgressManager.getInstance()
+                    .runProcess(fixture::doHighlighting, indicator);
+            return highlights != null && highlights.stream()
+                    .anyMatch(info -> info.getSeverity() == HighlightSeverity.ERROR);
+        } catch (Exception e) {
+            return false;
+        } finally {
+            cancelTask.cancel(false);
+        }
     }
 
     private static void sleep(long millis) {

--- a/src/test/java/com/sap/cap/cds/intellij/TestUtil.java
+++ b/src/test/java/com/sap/cap/cds/intellij/TestUtil.java
@@ -8,6 +8,7 @@ import com.intellij.testFramework.ExpectedHighlightingData;
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
 import com.redhat.devtools.lsp4ij.LanguageServerManager;
+import com.redhat.devtools.lsp4ij.ServerStatus;
 import com.sap.cap.cds.intellij.lsp4ij.CdsLanguageServer;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,7 +18,6 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import static java.nio.file.Files.readString;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestUtil {
@@ -46,23 +46,20 @@ public class TestUtil {
         var project = fixture.getProject();
         long deadline = System.currentTimeMillis() + SECONDS.toMillis(60);
 
+        // Wait for the server to reach 'started' status before calling doHighlighting().
+        // With lsp4ij >= 0.21.0 the feature support uses awaitWithCheckCanceled (no safety
+        // timeout), so triggering highlighting before the server is ready causes an indefinite
+        // hang in the test JVM.
         while (System.currentTimeMillis() < deadline) {
-            try {
-                var server = LanguageServerManager.getInstance(project)
-                    .getLanguageServer(CdsLanguageServer.ID)
-                    .get(100, MILLISECONDS);
-                if (server != null) {
-                    break;
-                }
-            } catch (Exception e) {
-                // retry until deadline
+            ServerStatus status = LanguageServerManager.getInstance(project)
+                    .getServerStatus(CdsLanguageServer.ID);
+            if (status == ServerStatus.started) {
+                break;
             }
             sleep(100);
         }
 
-        // The server object exists before it has finished indexing and
-        // published diagnostics; startup cost varies with machine speed, so
-        // poll for the diagnostics to arrive rather than waiting a fixed delay.
+        // Poll for diagnostics to arrive (server may still be indexing after started).
         while (System.currentTimeMillis() < deadline) {
             if (hasErrorDiagnostics(fixture)) {
                 return;


### PR DESCRIPTION
# Chore: Bump LSP4IJ Plugin Dependency to 0.21.0

### Chore

🔧 Updated the `lsp4ij` plugin dependency version from `0.20.1` to `0.21.0` in the build configuration.

### Changes

* `build.gradle`: Updated the `com.redhat.devtools.lsp4ij` plugin version from `0.20.1` to `0.21.0`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.14`

- Correlation ID: `f661a0e0-aa8d-11f1-8b5b-92d0ff3d2ec3`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
