### PR TITLE
chore: dummy 3.0.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 archiveName = cds-intellij.zip
 pluginRepositoryUrl = https://github.com/cap-js/cds-intellij
 # SemVer format -> https://semver.org
-pluginVersion = 3.0.0
+pluginVersion = 3.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251


### PR DESCRIPTION
# Bump Plugin Version to 3.0.1

### Chore

🔧 Bumps the plugin version from `3.0.0` to `3.0.1` in the project configuration.

### Changes

* `gradle.properties`: Updated `pluginVersion` from `3.0.0` to `3.0.1`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.20`

- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `7a4c8aa0-ad0e-11f1-812a-15440990b1bc`
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
